### PR TITLE
Eleenest dev b 194681922 i2c fix

### DIFF
--- a/source/daplink/cmsis-dap/DAP_vendor.c
+++ b/source/daplink/cmsis-dap/DAP_vendor.c
@@ -195,13 +195,14 @@ uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response) {
         //    connector J1305 (with pullups to 1.8V).  It uses the MCU's internal I2C2 hw block.
 
         //  The inputs to this command are:
-        //    I2C_TargetAddress
-        //    I2C_starting_register_address
-        //    Read_length (1 to 61 bytes is valid)
-        //  Each input is 1 byte long.
+        //    I2C_TargetAddress, 1 byte (7 bit I2C chip address)
+        //    I2C_starting_register_address, 1 byte
+        //    Read_length, 1 byte (1 to 61 bytes is valid)
         //
         //  This returns a byte array which contains:
         //    status byte (0x00 = Success, 0xFF = Failure)
+        //    I2C "event" status (2 bytes).  Search for "ARM_I2C_EVENT_TRANSFER_DONE" for bit definitions
+        //      0x01 is "done", 0x10 is "cleared", other bits indicate errors.
         //    length byte
         //    1 to 61 data bytes
         //
@@ -209,50 +210,71 @@ uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response) {
         const uint8_t* internal_addr = request++;
         uint8_t len = *request;
         uint8_t data_buf[64] = { 0 };
+        uint32_t returnVal = 0;
 
-        // can add additional responses from I2C_DAP_MasterRead to provide better status
-        if (I2C_DAP_MasterRead(target_addr, internal_addr, data_buf, len)) {
+
+        returnVal = I2C_DAP_MasterRead(target_addr, internal_addr, data_buf, len);
+        if (returnVal== 0x01) {
             *response++ = DAP_OK;
         } else {
-            // transfer incomplete
+            // transfer incomplete or error
             *response++ = DAP_ERROR;
-;
         }
+        *response++ = (returnVal & 0xFF); //9 bits in an event.  Get first byte
+        *response++ = ((returnVal >> 8) & 0xFF); //Get 2nd byte
         *response++ = len;  //length byte
 
         for (int i = 0; i < len; i++) {
             *response++ = data_buf[i];
         }
 
-        //3 bytes read for the command, returns status byte, length byte, and len data bytes
-        num += (3 << 16) | (2 + len);
+        //3 bytes read for the command, returns status byte, returnVal, length byte, and len data bytes
+        num += (3 << 16) | (4 + len);
         break;
     }
     case ID_DAP_Vendor16: {
-        // i2c write
+        //  Write I2C data
+        //
+        //  This writes data to the "I2C2" bus on the UDB board.  This is routed to an EEPROM
+        //    (24AA02UIDT) at address 0x50, a voltage measurement chip (PAC1934T-I/J6CX)
+        //    at address 0x17, and pins 13 and 15 of
+        //    connector J1305 (with pullups to 1.8V).  It uses the MCU's internal I2C2 hw block.
+
+        //  The inputs to this command are:
+        //    I2C_TargetAddress, 1 byte (7 bit I2C chip address)
+        //    I2C_starting_register_address, 1 byte
+        //    Write_length, 1 byte (1 to 60 bytes is valid)
+        //    Data, 1-60 bytes
+        //
+        //  This returns a byte array which contains:
+        //    status byte (0x00 = Success, 0xFF = Failure)
+        //    I2C "event" status (2 bytes).  Search for "ARM_I2C_EVENT_TRANSFER_DONE" for bit definitions
+        //      0x01 is "done", 0x10 is "cleared", other bits indicate errors.
+        //
         uint8_t target_addr = *request++;
         const uint8_t* internal_addr = request++;
         uint8_t len = *request++;
         uint8_t data_buf[60] = {0};
+        uint32_t returnVal = 0;
 
         for (int i = 0; i < len; i++) {
             data_buf[i] = *request++;
         }
 
-        // can add additional responses from I2C_DAP_MasterRead to provide better status
-        if (I2C_DAP_MasterTransfer(target_addr, internal_addr, data_buf, len)) {
+        // DONE: can add additional responses from I2C_DAP_MasterRead to provide better status
+        returnVal = I2C_DAP_MasterTransfer(target_addr, internal_addr, data_buf, len);
+        if (returnVal== 0x01) {
             // transfer done
-            *response++ = 0x00U;
+            *response++ = DAP_OK;
         } else {
             // transfer incomplete
-            *response++ = 0xFFU;
+            *response++ = DAP_ERROR;
         }
+        *response++ = (returnVal & 0xFF); //9 bits in an event.  Get first byte
+        *response++ = ((returnVal >> 8) & 0xFF); //Get 2nd byte
 
-        // optional
-        // clear out additional data in response to make pyOCD response cleaner
-        for (int i = 0; i < 62; i++) {
-            *response++ = 0x00U;
-        }
+        //3 + len bytes read for the command, 3 bytes returned (status, returnVal)
+        num += ((3 + len) << 16) | (3);
         break;
     }
     case ID_DAP_Vendor17: {

--- a/source/daplink/interface/main_interface.c
+++ b/source/daplink/interface/main_interface.c
@@ -252,6 +252,9 @@ void main_task(void * arg)
     // Initialize the DAP
     DAP_Setup();
 
+    // Initialize I2C (used for vendor commands)
+    I2C_DAP_Initialize();
+
     // make sure we have a valid board info structure.
     util_assert(g_board_info.info_version == kBoardInfoVersion);
 


### PR DESCRIPTION
I2C fixes.  

I confirmed that I could write a "page" of 8 bytes to the EEPROM, as shown below.
pyocd> $ probe._link.vendor(16, [0x50, 0x00, 0x08, 0x00, 0x01, 0x02, 0x03, 0x10, 0x11, 0x12, 0x13])
array('B', [0, 1, 0])

pyocd> $ probe._link.vendor(15, [0x50, 0x00, 0x08])[4:]
array('B', [0, 1, 2, 3, 16, 17, 18, 19])
